### PR TITLE
Adapt to P4est_jll v2.8 with MPI support

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,6 +1,6 @@
 [libp4est]
-git-tree-sha1 = "45086a10bb6c634ab1f35758ecaadcefbbbbaf13"
+git-tree-sha1 = "ab08f50b99b6c4060e331e5ece8352645c380dd5"
 
     [[libp4est.download]]
-    sha256 = "0ff5f74c9391a9e32fe517327819ac8917a906925605db0569a5beca7b45bcb8"
-    url = "https://github.com/trixi-framework/P4est_jll_bindings/releases/download/P4est-v2.3.1+0/P4est.v2.3.1.tar.gz"
+    sha256 = "837eacdd075584af5a5e5f727973b0a216717919ab6e2bdd0200b222c3c3f38d"
+    url = "https://github.com/lchristm/P4est_jll_bindings_test/releases/download/P4est-v2.8.0+0/P4est.v2.8.0.tar.gz"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,193 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+
+[[Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[CBinding]]
+deps = ["Libdl", "Random", "Test"]
+git-tree-sha1 = "358e34d0ea8823812d17525fc581fcc332cf4874"
+uuid = "d43a6710-96b8-4a2d-833c-c424785e5374"
+version = "0.9.4"
+
+[[CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[DocStringExtensions]]
+deps = ["LibGit2"]
+git-tree-sha1 = "b19534d1895d702889b219c382a6e18010797f0b"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.8.6"
+
+[[Downloads]]
+deps = ["ArgTools", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[JLLWrappers]]
+deps = ["Preferences"]
+git-tree-sha1 = "22df5b96feef82434b07327e2d3c770a9b21e023"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.4.0"
+
+[[LazyArtifacts]]
+deps = ["Artifacts", "Pkg"]
+uuid = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
+
+[[LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+
+[[LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+
+[[LibGit2]]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[MPI]]
+deps = ["Distributed", "DocStringExtensions", "Libdl", "MPICH_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "Pkg", "Random", "Requires", "Serialization", "Sockets"]
+git-tree-sha1 = "d56a80d8cf8b9dc3050116346b3d83432b1912c0"
+uuid = "da04e1cc-30fd-572f-bb4f-1f8673147195"
+version = "0.19.2"
+
+[[MPICH_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "443ed01e04190faf26680975df61272800b160af"
+uuid = "7cb0a576-ebde-5e09-9194-50597f1243b4"
+version = "3.4.3+1"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+
+[[MicrosoftMPI_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "a16aa086d335ed7e0170c5265247db29172af2f9"
+uuid = "9237b28f-5490-5468-be7b-bb81f5f5e6cf"
+version = "10.1.3+2"
+
+[[MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+
+[[NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+
+[[OpenMPI_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "Pkg"]
+git-tree-sha1 = "6340586e076b2abd41f5ba1a3b9c774ec6b30fde"
+uuid = "fe0851c0-eecd-5654-98d4-656369965a5c"
+version = "4.1.2+0"
+
+[[P4est_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "MPICH_jll", "MicrosoftMPI_jll", "Pkg", "Zlib_jll"]
+git-tree-sha1 = "a88bbdab37773f3575fc605689dd5f776cc23967"
+repo-rev = "main"
+repo-url = "https://github.com/lchristm/P4est_jll.jl"
+uuid = "6b5a15aa-cf52-5330-8376-5e5d90283449"
+version = "2.8.0+0"
+
+[[Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "2cf929d64681236a2e074ffafb8d568733d2e6af"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.2.3"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Reexport]]
+git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
+uuid = "189a3867-3050-52da-a836-e630ba90ab69"
+version = "1.2.2"
+
+[[Requires]]
+deps = ["UUIDs"]
+git-tree-sha1 = "838a3a4188e2ded87a4f9f184b4b0d78a1e91cb7"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "1.3.0"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+
+[[Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+
+[[Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+
+[[nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+
+[[p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "P4est"
 uuid = "7d669430-f675-4ae7-b43e-fab78ec5a902"
 authors = ["Michael Schlottke-Lakemper <michael@sloede.com>"]
-version = "0.2.4-pre"
+version = "0.3.0-prev"
 
 [deps]
 CBinding = "d43a6710-96b8-4a2d-833c-c424785e5374"
@@ -12,6 +12,6 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 [compat]
 CBinding = "0.9.2"
 MPI = "0.15, 0.16, 0.18, 0.19"
-P4est_jll = "~2.3.1"
+P4est_jll = "~2.8"
 Reexport = "0.2, 1.0"
 julia = "1.6"

--- a/README.md
+++ b/README.md
@@ -24,10 +24,9 @@ julia> import Pkg; Pkg.add("P4est")
 ```
 P4est.jl depends on the binary distribution of the [p4est](https://github.com/cburstedde/p4est)
 library, which is available in the Julia package `P4est_jll.jl` and which is automatically
-installed as a dependency.
-
-*Note: Currently, `P4est_jll.jl` only provides serial binaries without MPI
-support. This limitation is planned to be lifted in the future.*
+installed as a dependency. The binaries provided by `P4est_jll.jl` support MPI and are compiled
+against the MPI binaries provided by `MicrosoftMPI_jll.jl` on Windows and `MPICH_jll.jl` on all
+other platforms. Note that `MPI.jl` should be configured to use the same MPI binaries. 
 
 By default, P4est.jl provides pre-generated Julia bindings to all exported C
 functions of the underlying p4est library. You can force the build script to
@@ -38,7 +37,8 @@ re-generate the bindings by setting the environment variable
 Julia v1.7. See [issue #39](https://github.com/trixi-framework/P4est.jl/issues/39)
 for further discussions.*
 
-In addition, when `JULIA_P4EST_GENERATE_BINDINGS` is non-empty you can also
+### Using a custom build of p4est
+When `JULIA_P4EST_GENERATE_BINDINGS` is non-empty you can also
 configure P4est.jl to use a custom build of p4est. For this, set the following
 environment variables and build P4est.jl again afterwards:
 1. **Set `JULIA_P4EST_PATH`.**
@@ -65,10 +65,7 @@ julia --project -e 'ENV["JULIA_P4EST_GENERATE_BINDINGS"] = "yes";
 ```
 
 P4est.jl supports [p4est](https://github.com/cburstedde/p4est) both with and
-without MPI enabled. By default, it uses the p4est library from the binary
-Julia package `P4est_jll`, which currently is not compiled with MPI support.
-However, you may specify a custom p4est build with MPI enabled using the
-environment variables desribed above. In this case, you need to set a few
+without MPI enabled. If your custom build supports MPI, you need to set a few
 additional variables to make sure that P4est.jl can create the correct C
 bindings:
 1. **Set `JULIA_P4EST_USES_MPI` to `yes`.**
@@ -106,25 +103,29 @@ In the Julia REPL, first load the package P4est.jl
 ```julia
 julia> using P4est
 ```
+Then load and initialize MPI
+```julia
+julia> using MPI; MPI.Init()
+```
 You can then access the full [p4est](https://github.com/cburstedde/p4est) API that is defined
 by the headers. For example, to create a periodic connectivity and check its validity, execute
 the following lines:
 ```julia
 julia> conn_ptr = p4est_connectivity_new_periodic()
-Ptr{p4est_connectivity} @0x0000000001ad2080
+Ptr{p4est_connectivity} @0x0000000002412d20
 
 julia> p4est_connectivity_is_valid(conn_ptr)
 1
 
-julia> p4est_ptr = p4est_new_ext(sc_MPI_Comm(0), conn_ptr, 0, 2, 0, 0, C_NULL, C_NULL)
+julia> p4est_ptr = p4est_new_ext(MPI.COMM_WORLD, conn_ptr, 0, 2, 0, 0, C_NULL, C_NULL)
 Into p4est_new with min quadrants 0 level 2 uniform 0
 New p4est with 1 trees on 1 processors
 Initial level 2 potential global quadrants 16 per tree 16
 Done p4est_new with 10 total quadrants
-Ptr{p4est} @0x00000000029e9fc0
+Ptr{p4est} @0x0000000002dd1fd0
 
 julia> p4est_ = unsafe_wrap(p4est_ptr)
-p4est(mpicomm=0, mpisize=1, mpirank=0, mpicomm_owned=0, data_size=0x0000000000000000, user_pointer=Ptr{Nothing} @0x0000000000000000, revision=0, first_local_tree=0, last_local_tree=0, local_num_quadrants=10, global_num_quadrants=10, global_first_quadrant=Ptr{Int64} @0x00000000025b2880, global_first_position=Ptr{p4est_quadrant} @0x0000000001ee1390, connectivity=Ptr{p4est_connectivity} @0x000000000256de60, trees=Ptr{sc_array} @0x0000000002210e20, user_data_pool=Ptr{sc_mempool} @0x0000000000000000, quadrant_pool=Ptr{sc_mempool} @0x00000000020a5820, inspect=Ptr{p4est_inspect} @0x0000000000000000)
+p4est(mpicomm=1140850688, mpisize=1, mpirank=0, mpicomm_owned=0, data_size=0x0000000000000000, user_pointer=Ptr{Nothing} @0x0000000000000000, revision=0, first_local_tree=0, last_local_tree=0, local_num_quadrants=10, global_num_quadrants=10, global_first_quadrant=Ptr{Int64} @0x000000000280c760, global_first_position=Ptr{p4est_quadrant} @0x0000000002a1d270, connectivity=Ptr{p4est_connectivity} @0x0000000002412d20, trees=Ptr{sc_array} @0x0000000002756960, user_data_pool=Ptr{sc_mempool} @0x0000000000000000, quadrant_pool=Ptr{sc_mempool} @0x0000000002dd1e40, inspect=Ptr{p4est_inspect} @0x0000000000000000)
 
 julia> p4est_.connectivity == conn_ptr
 true

--- a/deps/Artifacts.toml
+++ b/deps/Artifacts.toml
@@ -1,6 +1,6 @@
 [libp4est]
-git-tree-sha1 = "45086a10bb6c634ab1f35758ecaadcefbbbbaf13"
+git-tree-sha1 = "ab08f50b99b6c4060e331e5ece8352645c380dd5"
 
     [[libp4est.download]]
-    sha256 = "0ff5f74c9391a9e32fe517327819ac8917a906925605db0569a5beca7b45bcb8"
-    url = "https://github.com/trixi-framework/P4est_jll_bindings/releases/download/P4est-v2.3.1+0/P4est.v2.3.1.tar.gz"
+    sha256 = "837eacdd075584af5a5e5f727973b0a216717919ab6e2bdd0200b222c3c3f38d"
+    url = "https://github.com/lchristm/P4est_jll_bindings_test/releases/download/P4est-v2.8.0+0/P4est.v2.8.0.tar.gz"

--- a/deps/Project.toml
+++ b/deps/Project.toml
@@ -5,5 +5,5 @@ P4est_jll = "6b5a15aa-cf52-5330-8376-5e5d90283449"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [compat]
-MPI = "0.15, 0.16"
-P4est_jll = "~2.3.1"
+MPI = "0.15, 0.16, 0.18, 0.19"
+P4est_jll = "~2.8"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -128,13 +128,14 @@ else
   if isempty(p4est_include)
     p4est_include = joinpath(dirname(dirname(P4est_jll.libp4est_path)), "include")
     println("Use p4est include path provided by P4est_jll")
+    use_p4est_jll = true
   end
 
   push!(include_directories, p4est_include)
 
 
   # Step 3b: Choose the MPI include path according to the settings
-  if config["p4est_uses_mpi"] == "yes"
+  if config["p4est_uses_mpi"] == "yes" || use_p4est_jll # P4est_jll uses MPI
     mpi_include = ""
     if !isempty(config["mpi_include"])
       mpi_include = config["mpi_include"]


### PR DESCRIPTION
- New p4est library required new bindings, thus the artifacts were adjusted
- The build.jl script automatically includes the MPI library provided by
  MPI.jl when re-generating bindings for P4est_jll
- The README was changed accordingly
- The tutorial in the README uses a proper MPI communicator now because
  the previously used function `sc_MPI_Comm` is only defined if
  p4est is compiled without MPI support
- The point above also implies that this is a breaking change, hence
  the version number was changed as well